### PR TITLE
Refactor transaction signing to use WASM SDK keypair

### DIFF
--- a/src/lib/utils/signer-data.ts
+++ b/src/lib/utils/signer-data.ts
@@ -50,9 +50,20 @@ export class PrivateKeyWallet {
         }
         const keypair = keypairFromBech32PrivateKey(senderAccount.bech32PrivateKey);
         let client = getLegacyClient();
-        return client.signAndExecuteTransaction({
-            transaction: params.transaction as any,
-            signer: keypair as any,
+
+        // Build the transaction bytes using the legacy client (handles gas resolution)
+        const transaction = params.transaction as Transaction;
+        transaction.setSenderIfNotSet(senderAddress);
+        const txBytes = await transaction.build({ client });
+
+        // Sign with WASM SDK keypair
+        const wasmTx = transactionFromBcs(txBytes.buffer as ArrayBuffer);
+        const sig = await keypair.signTransaction(wasmTx);
+
+        // Execute using the legacy client with pre-signed data
+        return client.executeTransactionBlock({
+            transactionBlock: txBytes,
+            signature: sig.toBase64(),
             options: params.options,
         });
     }


### PR DESCRIPTION
## Summary
Refactored the transaction signing flow in `PrivateKeyWallet` to explicitly build transaction bytes, sign with the WASM SDK keypair, and execute with pre-signed data, rather than relying on the legacy client's combined `signAndExecuteTransaction` method.

## Key Changes
- Split the combined `signAndExecuteTransaction` call into separate steps:
  - Build transaction bytes using the legacy client (preserves gas resolution handling)
  - Sign the transaction using the WASM SDK keypair's `signTransaction` method
  - Execute the transaction block with pre-signed signature data
- Added explicit transaction sender assignment via `setSenderIfNotSet()`
- Convert transaction bytes to WASM transaction format before signing
- Pass signature as Base64-encoded string to `executeTransactionBlock()`

## Implementation Details
- The legacy client is still used for transaction building to maintain existing gas resolution behavior
- Transaction bytes are converted between formats using `transactionFromBcs()` to ensure compatibility with the WASM SDK keypair signing
- The signature is converted to Base64 format before being passed to the execution method

https://claude.ai/code/session_01RFhZp2jnxhYQhAq5h2HKHC