### PR TITLE
feat(StakingRewards): ignore-previous-rewards option + fetch correctness fixes

### DIFF
--- a/src/lib/pages/staking-rewards/StakingRewards.svelte
+++ b/src/lib/pages/staking-rewards/StakingRewards.svelte
@@ -13,7 +13,9 @@
     // @ts-ignore
     import exchangeRateCacheBinary from './cache/exchange-rate-cache.bin?raw';
     import epochTimestampsCacheJson from './cache/mainnet-epoch-timestamps-cache.json';
+    import { formatNanoAsIota } from './formatting';
     import { fetchCurrentStakedObjects, fetchEpochTimestampsForDisplay } from './graphql-requests';
+    import { mapWithConcurrency } from './graphql-retry';
     import {
         fetchReceivedStakeTransactions,
         fetchStakeTransactions,
@@ -24,7 +26,7 @@
     } from './index';
     import StakingRewardsChart from './StakingRewardsChart.svelte';
     import StakingRewardsTable from './StakingRewardsTable.svelte';
-    import { computeEpochData } from './table-utils';
+    import { computeEpochData, rebaselineStakeObjects } from './table-utils';
     import {
         filterEpochsByTimeFrame,
         getDateRangeForEpochRange,
@@ -52,6 +54,7 @@
         customEpochStart: '',
         customEpochEnd: '',
         fetchReceivedTxs: false,
+        ignorePreviousRewards: false,
     });
 
     // One-shot snapshot used to seed local state that's either bound with
@@ -163,6 +166,10 @@
     let loadingTxs = false;
     let loadingStep: string | null = null;
     let fetchReceivedTxs = initialQueryParams.fetchReceivedTxs;
+    // When on (and a narrower time frame than "All time" is selected), rewards
+    // accrued before the window are removed from the report. Defaults to off so
+    // the output is unchanged unless the user explicitly enables it.
+    let ignorePreviousRewards = initialQueryParams.ignorePreviousRewards;
     let showPriceColumns = true;
     let showValidatorColumns = true;
     let noTransactionsFound = false;
@@ -244,6 +251,9 @@
     $: updatePageQueryParams({
         fetchReceivedTxs: fetchReceivedTxs ? true : null,
     });
+    $: updatePageQueryParams({
+        ignorePreviousRewards: ignorePreviousRewards ? true : null,
+    });
 
     $: customDateRange =
         selectedTimeFrame === 'custom' && customDateStart && customDateEnd
@@ -323,6 +333,35 @@
         return idx >= 0 ? epochEndDates[idx] : '';
     });
 
+    // "Ignore previous rewards" — only meaningful for a narrower time frame than
+    // "All time". The window start is the first epoch actually displayed; every
+    // reward accrued before it is stripped from the figures (table, chart,
+    // export). When the option is off, displayStakeObjects === stakeObjects so
+    // the output is byte-for-byte unchanged.
+    $: rebaseStartEpoch =
+        ignorePreviousRewards && selectedTimeFrame !== 'all' && timeFrameFilteredEpochs.length > 0
+            ? timeFrameFilteredEpochs[0]
+            : undefined;
+
+    $: rebaseResult =
+        rebaseStartEpoch !== undefined
+            ? rebaselineStakeObjects(stakeObjects, rebaseStartEpoch)
+            : null;
+
+    $: displayStakeObjects = rebaseResult ? rebaseResult.stakeObjects : stakeObjects;
+
+    $: previousRewardsRemoved = rebaseResult ? rebaseResult.previousRewardsRemoved : 0n;
+
+    $: previousRewardsNotice =
+        rebaseStartEpoch !== undefined && previousRewardsRemoved > 0n
+            ? `Previous rewards ignored: ${formatNanoAsIota(previousRewardsRemoved)} — accrued before epoch ${rebaseStartEpoch}`
+            : '';
+
+    // Re-based epoch data drives the chart so it matches the table/export.
+    $: displayTableData = rebaseResult
+        ? computeEpochData(displayStakeObjects, validatorInfo, epoch || 1)
+        : tableData;
+
     // Only tell the chart to drop its last epoch when the filter ends at the
     // pending current epoch (that epoch has partial data). For closed ranges
     // that end earlier, every epoch in the filter is complete and should render.
@@ -335,7 +374,7 @@
             tableData.epochs[tableData.epochs.length - 1];
 
     $: filteredTableDataForChart = {
-        ...tableData,
+        ...displayTableData,
         epochs: timeFrameFilteredEpochs,
     };
 
@@ -452,57 +491,66 @@
                     `Fetching ${phaseLabel} txs ${baseDone}/${total}` + ` (${foundSoFar} found)...`;
             }
 
-            const allTxsPromises = allAddresses.map(async (addr) => {
-                try {
-                    const sentKey = `sent:${addr}`;
-                    inFlight.set(sentKey, { role: 'sent', transactions: 0 });
-                    renderLoadingStep('stake');
-                    const sentTxs = await fetchStakeTransactions(addr, {
-                        startEpoch,
-                        skipPaginationSenders: skipSendersSnapshot,
-                        onSkipPagination: recordSkippedSender,
-                        onProgress: ({ transactions }) => {
-                            const entry = inFlight.get(sentKey);
-                            if (entry) {
-                                entry.transactions = transactions;
-                                renderLoadingStep('stake');
-                            }
-                        },
-                    });
-                    inFlight.delete(sentKey);
-                    sentDone++;
-                    renderLoadingStep('stake');
-
-                    let receivedTxs: any[] = [];
-                    if (fetchReceivedTxs) {
-                        const recvKey = `recv:${addr}`;
-                        inFlight.set(recvKey, { role: 'received', transactions: 0 });
-                        renderLoadingStep('received');
-                        receivedTxs = await fetchReceivedStakeTransactions(addr, {
+            // Cap how many addresses fetch at once. Each address fans out into
+            // many sequential GraphQL requests (paginated sent/received txs +
+            // objectChanges), so running every address in parallel floods the
+            // endpoint and trips its rate limiter (HTTP 429). A small pool keeps
+            // throughput high without the burst; per-request retries in
+            // graphql-requests.ts absorb any 429s that still slip through.
+            const ADDRESS_FETCH_CONCURRENCY = 10;
+            const allTxsResults = await mapWithConcurrency(
+                allAddresses,
+                ADDRESS_FETCH_CONCURRENCY,
+                async (addr) => {
+                    try {
+                        const sentKey = `sent:${addr}`;
+                        inFlight.set(sentKey, { role: 'sent', transactions: 0 });
+                        renderLoadingStep('stake');
+                        const sentTxs = await fetchStakeTransactions(addr, {
                             startEpoch,
                             skipPaginationSenders: skipSendersSnapshot,
                             onSkipPagination: recordSkippedSender,
                             onProgress: ({ transactions }) => {
-                                const entry = inFlight.get(recvKey);
+                                const entry = inFlight.get(sentKey);
                                 if (entry) {
                                     entry.transactions = transactions;
-                                    renderLoadingStep('received');
+                                    renderLoadingStep('stake');
                                 }
                             },
                         });
-                        inFlight.delete(recvKey);
-                        receivedDone++;
-                        renderLoadingStep('received');
+                        inFlight.delete(sentKey);
+                        sentDone++;
+                        renderLoadingStep('stake');
+
+                        let receivedTxs: any[] = [];
+                        if (fetchReceivedTxs) {
+                            const recvKey = `recv:${addr}`;
+                            inFlight.set(recvKey, { role: 'received', transactions: 0 });
+                            renderLoadingStep('received');
+                            receivedTxs = await fetchReceivedStakeTransactions(addr, {
+                                startEpoch,
+                                skipPaginationSenders: skipSendersSnapshot,
+                                onSkipPagination: recordSkippedSender,
+                                onProgress: ({ transactions }) => {
+                                    const entry = inFlight.get(recvKey);
+                                    if (entry) {
+                                        entry.transactions = transactions;
+                                        renderLoadingStep('received');
+                                    }
+                                },
+                            });
+                            inFlight.delete(recvKey);
+                            receivedDone++;
+                            renderLoadingStep('received');
+                        }
+
+                        return { sentTxs, receivedTxs, address: addr, error: null };
+                    } catch (err) {
+                        console.error(`Failed to fetch transactions for address ${addr}:`, err);
+                        return { sentTxs: [], receivedTxs: [], address: addr, error: err };
                     }
-
-                    return { sentTxs, receivedTxs, address: addr, error: null };
-                } catch (err) {
-                    console.error(`Failed to fetch transactions for address ${addr}:`, err);
-                    return { sentTxs: [], receivedTxs: [], address: addr, error: err };
-                }
-            });
-
-            const allTxsResults = await Promise.all(allTxsPromises);
+                },
+            );
 
             // Check if any addresses had errors
             const failedAddresses = allTxsResults.filter((r) => r.error);
@@ -811,6 +859,31 @@
                     </span>
                 {/if}
             </div>
+            {#if selectedTimeFrame !== 'all'}
+                <label class="toggle-row">
+                    <div class="toggle-switch">
+                        <input type="checkbox" bind:checked={ignorePreviousRewards} />
+                        <span class="slider"></span>
+                    </div>
+                    <div style="display: flex; flex-direction: column; line-height: 1.2;">
+                        <div style="display: flex; align-items: center; gap: 0.25rem;">
+                            <span class="toggle-label"> Ignore previous rewards </span>
+                            <div class="tooltip-container">
+                                <span class="info-icon">ⓘ</span>
+                                <div class="tooltip">
+                                    Removes rewards that accrued before the selected time frame.
+                                    Accumulated, available, and unstake rewards are re-based to
+                                    start at the window, and the amount removed is shown in the
+                                    report and exports.
+                                </div>
+                            </div>
+                        </div>
+                        <span style="font-size: 0.75rem; opacity: 0.7;"
+                            >Report only rewards earned within the selected time frame</span
+                        >
+                    </div>
+                </label>
+            {/if}
             <button
                 onclick={fetchTransactions}
                 disabled={loadingTxs}
@@ -855,11 +928,16 @@
                 .join(', ')}{filteredNegativeEpochs.length > 10 ? '…' : ''}
         </div>
     {/if}
+    {#if previousRewardsNotice && stakeObjects.length > 0}
+        <div class="info-message">
+            {previousRewardsNotice}
+        </div>
+    {/if}
 
     <div class="summary-section">
         <StakingRewardsTable
             currentEpoch={epoch || 1}
-            {stakeObjects}
+            stakeObjects={displayStakeObjects}
             {validatorInfo}
             bind:showPriceColumns
             bind:showValidatorColumns
@@ -867,6 +945,7 @@
             {noTransactionsFound}
             {timeFrameFilteredEpochs}
             {exportFileName}
+            {previousRewardsNotice}
         />
     </div>
     {#if stakeObjects.length > 0}

--- a/src/lib/pages/staking-rewards/StakingRewardsTable.svelte
+++ b/src/lib/pages/staking-rewards/StakingRewardsTable.svelte
@@ -79,6 +79,7 @@
         noTransactionsFound = false,
         timeFrameFilteredEpochs = undefined as number[] | undefined,
         exportFileName = '' as string,
+        previousRewardsNotice = '' as string,
     } = $props();
 
     let windowWidth = $state(0);
@@ -317,6 +318,7 @@
             fileName: opts.fileName || exportFileName,
             wrapStakeObjects: opts.wrapStakeObjects,
             wrapValidators: opts.wrapValidators,
+            ...(previousRewardsNotice && { previousRewardsNotice }),
         };
 
         const onProgress = (p: ExportProgress) => {
@@ -504,6 +506,7 @@
                 selectedCurrency,
                 wrapStakeObjects: opts.wrapStakeObjects,
                 wrapValidators: opts.wrapValidators,
+                ...(previousRewardsNotice && { previousRewardsNotice }),
             },
             previewRowLimit,
         })}

--- a/src/lib/pages/staking-rewards/compute/processor.ts
+++ b/src/lib/pages/staking-rewards/compute/processor.ts
@@ -1195,9 +1195,13 @@ export async function processStakeTransactionsWithExchangeRates(
     if (currentStakeObjects && currentStakeObjects.length > 0) {
         supplementMissingStakeObjects(allStakeObjects, currentStakeObjects, currentEpoch);
     }
-    if (startEpoch !== undefined) {
-        extendFirstEpochToActivation(allStakeObjects, startEpoch);
-    }
+    // Reconstruct pre-history for objects whose creation tx was never captured
+    // (stakeActivationEpoch < firstEpoch). This happens both for time-frame fetches
+    // (creation filtered out) and for "all time" fetches where an old object's
+    // creation/input state was pruned and only its unstake survives via recovery.
+    // Normal objects (firstEpoch == stakeActivationEpoch) are never touched, so it
+    // is safe to run unconditionally; `startEpoch ?? 0` keeps all candidates eligible.
+    extendFirstEpochToActivation(allStakeObjects, startEpoch ?? 0);
 
     // Finalize lastEpoch for all stake objects based on their complete action history
     // This ensures correct behavior when multiple actions happen in the same epoch

--- a/src/lib/pages/staking-rewards/csv-export.test.ts
+++ b/src/lib/pages/staking-rewards/csv-export.test.ts
@@ -197,4 +197,31 @@ describe('CSV / PDF export - snapshot', () => {
         const [main] = buildExportSections({ ...baseInputs, options });
         expect(main.headers.some((h) => h.startsWith('Total Earned'))).toBe(false);
     });
+
+    it('renders the "previous rewards ignored" notice as the main section title in the CSV', () => {
+        const notice = 'Previous rewards ignored: 31.00 IOTA — accrued before epoch 131';
+        const options: ExportOptions = {
+            showPriceColumns: false,
+            showValidatorColumns: false,
+            epochPrices: {},
+            selectedCurrency: 'usd',
+            previousRewardsNotice: notice,
+        };
+        const sections = buildExportSections({ ...baseInputs, options });
+        expect(sections[0].title).toBe(notice);
+        // And it makes it into the serialized CSV ahead of the header row.
+        const csv = sectionsToCsv([sections[0]]);
+        expect(csv.indexOf(notice)).toBeLessThan(csv.indexOf('Epoch'));
+    });
+
+    it('omits the notice title when the option is not active', () => {
+        const options: ExportOptions = {
+            showPriceColumns: false,
+            showValidatorColumns: false,
+            epochPrices: {},
+            selectedCurrency: 'usd',
+        };
+        const [main] = buildExportSections({ ...baseInputs, options });
+        expect(main.title).toBeUndefined();
+    });
 });

--- a/src/lib/pages/staking-rewards/csv-export.ts
+++ b/src/lib/pages/staking-rewards/csv-export.ts
@@ -184,7 +184,12 @@ export function buildExportSections(inputs: ExportInputs): ExportSection[] {
     }
 
     const sections: ExportSection[] = [
-        { headers: mainHeaders, rows: mainRows, ...(mainTruncated && { truncated: true }) },
+        {
+            ...(options.previousRewardsNotice && { title: options.previousRewardsNotice }),
+            headers: mainHeaders,
+            rows: mainRows,
+            ...(mainTruncated && { truncated: true }),
+        },
     ];
 
     if (wrapValidators && showValidatorColumns && uniqueValidators.length > 0) {

--- a/src/lib/pages/staking-rewards/graphql-requests.ts
+++ b/src/lib/pages/staking-rewards/graphql-requests.ts
@@ -9,6 +9,7 @@ import {
 } from './cache/binary-cache';
 import { getInactiveValidatorsWithDeactivationEpoch } from './compute/validator-utils';
 import { formatDate } from './formatting';
+import { queryWithRetry } from './graphql-retry';
 
 /**
  * Returns the first checkpoint sequence number of the given epoch, or null if
@@ -28,7 +29,7 @@ async function fetchFirstCheckpointForEpoch(epochId: number): Promise<number | n
             }
         }
     }`;
-    const result = await gqlClient.query({ query, variables: { epochId } });
+    const result = await queryWithRetry(gqlClient, { query, variables: { epochId } });
     // @ts-ignore
     const seq = result.data?.epoch?.checkpoints?.nodes?.[0]?.sequenceNumber;
     if (seq === undefined || seq === null) return null;
@@ -64,9 +65,119 @@ export type FetchStakeTxsOptions = {
     onSkipPagination?: (senderAddress: string) => void;
 };
 
+/**
+ * Shape a past StakedIota / TimelockedStakedIota's JSON-RPC fields into the same
+ * structure `extractStakeObjectData` reads from a GraphQL `inputState.json`, so a
+ * recovered object is processed exactly like a normally-fetched one.
+ */
+function shapeRecoveredStakeJson(type: string, fields: any): any | null {
+    if (!fields) return null;
+    const normalizePrincipal = (p: any) =>
+        p && typeof p === 'object' ? (p.value ?? p.fields?.value) : p;
+    if (type.includes('staking_pool::StakedIota')) {
+        return {
+            pool_id: fields.pool_id,
+            principal: { value: normalizePrincipal(fields.principal) },
+            stake_activation_epoch: fields.stake_activation_epoch,
+        };
+    }
+    if (type.includes('timelocked_staking::TimelockedStakedIota')) {
+        // Nested struct may arrive as { fields: {...} } or flattened.
+        const si = fields.staked_iota?.fields ?? fields.staked_iota;
+        if (!si) return null;
+        return {
+            staked_iota: {
+                pool_id: si.pool_id,
+                principal: { value: normalizePrincipal(si.principal) },
+                stake_activation_epoch: si.stake_activation_epoch,
+            },
+        };
+    }
+    return null;
+}
+
+/**
+ * Backfill `inputState` for unstaked stake objects whose historical version was
+ * pruned from GraphQL. Only runs for transactions that call
+ * `iota_system::request_withdraw_stake*`, and only for deleted objects with a
+ * known input version — keeping the extra JSON-RPC calls bounded to real unstakes.
+ */
+async function recoverPrunedStakeInputStates(transactions: any[]): Promise<void> {
+    type Recovery = { node: any; address: string; version: number };
+    const recoveries: Recovery[] = [];
+
+    for (const tx of transactions) {
+        const kind = tx?.kind;
+        if (kind?.__typename !== 'ProgrammableTransactionBlock') continue;
+
+        const calls = kind.transactions?.nodes ?? [];
+        const hasWithdraw = calls.some(
+            (c: any) =>
+                c?.__typename === 'MoveCallTransaction' &&
+                c.module === 'iota_system' &&
+                typeof c.functionName === 'string' &&
+                c.functionName.startsWith('request_withdraw_stake'),
+        );
+        if (!hasWithdraw) continue;
+
+        const inputVersions = new Map<string, number>();
+        for (const input of kind.inputs?.nodes ?? []) {
+            if (
+                input?.__typename === 'OwnedOrImmutable' &&
+                input.address &&
+                input.version != null
+            ) {
+                inputVersions.set(input.address, Number(input.version));
+            }
+        }
+        if (inputVersions.size === 0) continue;
+
+        for (const node of tx.effects?.objectChanges?.nodes ?? []) {
+            const alreadyHasInput = !!node?.inputState?.asMoveObject?.contents;
+            if (node?.idDeleted !== true || alreadyHasInput) continue;
+            const version = inputVersions.get(node.address);
+            if (version == null) continue;
+            recoveries.push({ node, address: node.address, version });
+        }
+    }
+
+    if (recoveries.length === 0) return;
+
+    const client = getClient();
+    await Promise.all(
+        recoveries.map(async ({ node, address, version }) => {
+            try {
+                const res = await client.tryGetPastObject({
+                    id: address,
+                    version,
+                    options: { showContent: true, showType: true, showOwner: true },
+                });
+                if (res.status !== 'VersionFound') return;
+                const data: any = res.details;
+                const type: string = data?.type ?? data?.content?.type ?? '';
+                const json = shapeRecoveredStakeJson(type, data?.content?.fields);
+                if (!json) return;
+                const ownerAddress =
+                    data?.owner && typeof data.owner === 'object'
+                        ? data.owner.AddressOwner
+                        : undefined;
+                // Mirror the GraphQL inputState.asMoveObject shape the processor reads.
+                node.inputState = {
+                    asMoveObject: {
+                        owner: ownerAddress ? { owner: { address: ownerAddress } } : null,
+                        contents: { type: { repr: type }, json },
+                    },
+                };
+            } catch (err) {
+                console.warn(`Failed to recover pruned input state for ${address}@${version}`, err);
+            }
+        }),
+    );
+}
+
 async function fetchStakeTransactionsByRole(
     address: string,
-    role: 'signAddress' | 'recvAddress',
+    role: 'sentAddress' | 'recvAddress',
     options: FetchStakeTxsOptions = {},
     batchSize = 1,
 ) {
@@ -171,6 +282,29 @@ async function fetchStakeTransactionsByRole(
                         sender {
                             address
                         }
+                        kind {
+                            __typename
+                            ... on ProgrammableTransactionBlock {
+                                transactions {
+                                    nodes {
+                                        __typename
+                                        ... on MoveCallTransaction {
+                                            module
+                                            functionName
+                                        }
+                                    }
+                                }
+                                inputs {
+                                    nodes {
+                                        __typename
+                                        ... on OwnedOrImmutable {
+                                            address
+                                            version
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         effects {
                             timestamp
                             epoch {
@@ -186,7 +320,7 @@ ${objectChangesSection}
         `;
 
         const variables = { address };
-        const result = await gqlClient.query({ query, variables });
+        const result = await queryWithRetry(gqlClient, { query, variables });
         if (result.errors) {
             throw new Error(`GraphQL query error: ${JSON.stringify(result.errors)}`);
         }
@@ -236,7 +370,7 @@ ${objectChangesSection}
                         txDigest: tx.digest,
                         objectChangesCursor: objectEndCursor,
                     };
-                    const objectResult = await gqlClient.query({
+                    const objectResult = await queryWithRetry(gqlClient, {
                         query: objectChangesQuery,
                         variables: objectVariables,
                     });
@@ -289,6 +423,12 @@ ${objectChangesSection}
             break;
         }
     }
+    // Recover input states that GraphQL pruned (a StakedIota created long ago and
+    // never modified has its input version pruned from the indexer, so the unstake
+    // would otherwise be invisible). The full-node JSON-RPC still retains the past
+    // object, so we backfill the missing inputState before the stake-type filter.
+    await recoverPrunedStakeInputStates(allNodes);
+
     const stakeTypes = [
         '0x0000000000000000000000000000000000000000000000000000000000000003::staking_pool::StakedIota',
         '0x0000000000000000000000000000000000000000000000000000000000000003::timelocked_staking::TimelockedStakedIota',
@@ -326,7 +466,7 @@ ${objectChangesSection}
 }
 
 export async function fetchStakeTransactions(address: string, options?: FetchStakeTxsOptions) {
-    return fetchStakeTransactionsByRole(address, 'signAddress', options);
+    return fetchStakeTransactionsByRole(address, 'sentAddress', options);
 }
 
 export async function fetchReceivedStakeTransactions(

--- a/src/lib/pages/staking-rewards/graphql-retry.ts
+++ b/src/lib/pages/staking-rewards/graphql-retry.ts
@@ -1,0 +1,78 @@
+import type { IotaGraphQLClient } from '@iota/iota-sdk/graphql';
+
+// Retry tuning. Fetching many addresses fans out into hundreds of GraphQL
+// requests; the public endpoint answers bursts with HTTP 429, which the browser
+// surfaces as a thrown `TypeError: Failed to fetch` (net::ERR_FAILED) rather
+// than a readable status. We retry those with exponential backoff + jitter so a
+// transient rate-limit doesn't abort an entire address's fetch.
+const MAX_RETRIES = 6;
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 30000;
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * True for errors worth retrying: rate-limit responses and transient network
+ * failures. A 429 from the GraphQL server reaches the browser as a thrown
+ * `TypeError: Failed to fetch`, so that case is covered both by the TypeError
+ * check and the message regex.
+ */
+function isRetryableError(err: unknown): boolean {
+    if (err instanceof TypeError) return true; // "Failed to fetch"
+    const msg = err instanceof Error ? err.message : String(err);
+    return /429|too many requests|failed to fetch|networkerror|econnreset|timeout/i.test(msg);
+}
+
+/**
+ * Run a GraphQL query, retrying on rate-limit / transient network errors with
+ * exponential backoff and jitter. Non-retryable errors (and the final attempt)
+ * are rethrown unchanged so callers keep their existing error handling.
+ */
+export async function queryWithRetry<T = any>(
+    gqlClient: IotaGraphQLClient,
+    args: { query: string; variables?: Record<string, unknown> },
+): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+        try {
+            return (await gqlClient.query(args as any)) as T;
+        } catch (err) {
+            if (attempt >= MAX_RETRIES || !isRetryableError(err)) {
+                throw err;
+            }
+            const backoff = Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS);
+            const wait = backoff + Math.random() * backoff * 0.5; // up to +50% jitter
+            console.warn(
+                `GraphQL request failed (${err instanceof Error ? err.message : String(err)}); ` +
+                    `retrying in ${Math.round(wait)}ms (attempt ${attempt + 1}/${MAX_RETRIES})`,
+            );
+            await delay(wait);
+        }
+    }
+}
+
+/**
+ * Map over `items` running at most `limit` calls of `fn` concurrently. Results
+ * are returned in input order. Used to cap how many addresses fetch in parallel
+ * so the GraphQL endpoint isn't flooded (the prior `Promise.all(map(...))` ran
+ * every address at once, which tripped server rate limits).
+ */
+export async function mapWithConcurrency<T, R>(
+    items: T[],
+    limit: number,
+    fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+    const results = Array.from<R>({ length: items.length });
+    let next = 0;
+    async function worker(): Promise<void> {
+        while (true) {
+            const i = next++;
+            if (i >= items.length) return;
+            results[i] = await fn(items[i], i);
+        }
+    }
+    const workerCount = Math.max(1, Math.min(limit, items.length));
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+    return results;
+}

--- a/src/lib/pages/staking-rewards/table-utils.test.ts
+++ b/src/lib/pages/staking-rewards/table-utils.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import type { StakeObject } from './compute/types';
+import { computeEpochData, rebaselineStakeObjects } from './table-utils';
+
+const IOTA = 1_000_000_000n; // 1 IOTA in nano
+
+/**
+ * Build the scenario from the feature request: a single stake earning 1 IOTA
+ * per epoch from epoch 100, fully unstaked at epoch 140.
+ *
+ *   - epochs 100..130 (31 epochs) accrue "December" rewards → 31 IOTA
+ *   - epochs 131..139 (9 epochs) accrue "January" rewards → 9 IOTA
+ *   - epoch 140 is the unstake epoch (no reward earned), realizing 40 IOTA
+ */
+function buildSingleStakeFullUnstake(): StakeObject {
+    const rewardsByEpoch: Record<number, string> = {};
+    const accumulatedRewards: Record<number, string> = {};
+    let accumulated = 0n;
+    for (let epoch = 100; epoch <= 139; epoch++) {
+        rewardsByEpoch[epoch] = IOTA.toString();
+        accumulated += IOTA;
+        accumulatedRewards[epoch] = accumulated.toString();
+    }
+    // Unstake epoch: rewards/accumulated reset to 0, realized rewards recorded
+    // on the action (matches rewards-calculator.ts behaviour).
+    rewardsByEpoch[140] = '0';
+    accumulatedRewards[140] = '0';
+
+    return {
+        objectId: 'obj1',
+        wasOwnedByTargetAddress: true,
+        poolId: 'pool1',
+        principalByEpoch: {},
+        exchangeRatesByEpoch: {},
+        rewardsByEpoch,
+        accumulatedRewards,
+        actionByEpoch: {
+            140: [{ action: 'Unstaked', digest: '0xabc', totalRewards: (40n * IOTA).toString() }],
+        },
+        firstEpoch: 100,
+        lastEpoch: 140,
+        stakeActivationEpoch: 100,
+    };
+}
+
+describe('rebaselineStakeObjects', () => {
+    it('strips pre-window rewards and re-bases the feature-request example', () => {
+        const stake = buildSingleStakeFullUnstake();
+        // Window = "January" → first displayed epoch is 131.
+        const { stakeObjects, previousRewardsRemoved } = rebaselineStakeObjects([stake], 131);
+
+        // 31 IOTA of December rewards removed.
+        expect(previousRewardsRemoved).toBe(31n * IOTA);
+
+        const rebased = stakeObjects[0];
+
+        // Per-epoch rewards before the window are zeroed.
+        expect(rebased.rewardsByEpoch[130]).toBe('0');
+        expect(rebased.rewardsByEpoch[100]).toBe('0');
+        // Within the window they are untouched.
+        expect(rebased.rewardsByEpoch[131]).toBe(IOTA.toString());
+        expect(rebased.rewardsByEpoch[139]).toBe(IOTA.toString());
+
+        // Accumulated re-bases to start at the window.
+        expect(rebased.accumulatedRewards[130]).toBe('0');
+        expect(rebased.accumulatedRewards[131]).toBe(IOTA.toString()); // 32 - 31
+        expect(rebased.accumulatedRewards[139]).toBe((9n * IOTA).toString()); // 40 - 31
+
+        // The unstake at epoch 140 now realizes only the 9 IOTA earned in January.
+        expect(rebased.actionByEpoch?.[140][0].totalRewards).toBe((9n * IOTA).toString());
+    });
+
+    it('makes the unstake-rewards total reflect only window rewards via computeEpochData', () => {
+        const stake = buildSingleStakeFullUnstake();
+        const { stakeObjects } = rebaselineStakeObjects([stake], 131);
+        const table = computeEpochData(
+            stakeObjects,
+            { pool1: { name: 'V', poolId: 'pool1' } },
+            140,
+        );
+
+        // Realized unstake rewards in the window = 9 IOTA (was 40 IOTA).
+        expect(table.epochData[140].totalUnstakeRewards).toBe(9n * IOTA);
+        // Cumulative rewards earned in the window peak at 9 IOTA before the unstake.
+        expect(table.epochData[139].totalAccumulated).toBe(9n * IOTA);
+    });
+
+    it('leaves objects that start inside the window untouched (no baseline)', () => {
+        const stake = buildSingleStakeFullUnstake();
+        // Window starts before the stake's first epoch → nothing to remove.
+        const { stakeObjects, previousRewardsRemoved } = rebaselineStakeObjects([stake], 100);
+        expect(previousRewardsRemoved).toBe(0n);
+        expect(stakeObjects[0].accumulatedRewards[139]).toBe((40n * IOTA).toString());
+        expect(stakeObjects[0].actionByEpoch?.[140][0].totalRewards).toBe((40n * IOTA).toString());
+    });
+
+    it('does not over-subtract the baseline across multiple window unstakes', () => {
+        // Pre-window accrued 10 IOTA; two partial unstakes inside the window each
+        // realize 6 IOTA. The 10 IOTA baseline must be absorbed once across both
+        // (6 from the first, 4 from the second), never 10 from each.
+        const stake: StakeObject = {
+            objectId: 'obj1',
+            wasOwnedByTargetAddress: true,
+            poolId: 'pool1',
+            principalByEpoch: {},
+            exchangeRatesByEpoch: {},
+            rewardsByEpoch: { 50: (10n * IOTA).toString() },
+            accumulatedRewards: { 50: (10n * IOTA).toString() },
+            actionByEpoch: {
+                60: [
+                    {
+                        action: 'Partial Unstake',
+                        digest: '0x1',
+                        totalRewards: (6n * IOTA).toString(),
+                    },
+                ],
+                61: [
+                    {
+                        action: 'Partial Unstake',
+                        digest: '0x2',
+                        totalRewards: (6n * IOTA).toString(),
+                    },
+                ],
+            },
+            firstEpoch: 50,
+            lastEpoch: 61,
+            stakeActivationEpoch: 50,
+        };
+
+        const { stakeObjects, previousRewardsRemoved } = rebaselineStakeObjects([stake], 55);
+        expect(previousRewardsRemoved).toBe(10n * IOTA);
+        // First unstake fully absorbed (6 - 6 = 0), second partially (6 - 4 = 2).
+        expect(stakeObjects[0].actionByEpoch?.[60][0].totalRewards).toBe('0');
+        expect(stakeObjects[0].actionByEpoch?.[61][0].totalRewards).toBe((2n * IOTA).toString());
+    });
+});

--- a/src/lib/pages/staking-rewards/table-utils.ts
+++ b/src/lib/pages/staking-rewards/table-utils.ts
@@ -7,6 +7,123 @@ import type { ActionDetails, StakeObject, ValidatorInfo } from './compute/types'
 import { formatNanoAsIota, nanoToIota } from './formatting';
 import type { EpochData, EpochDataEntry, TableComputationResult } from './types';
 
+function safeBigInt(value: string | undefined): bigint {
+    if (!value) return 0n;
+    try {
+        return BigInt(value);
+    } catch {
+        return 0n;
+    }
+}
+
+/**
+ * Accumulated rewards a stake object had earned strictly before `startEpoch`.
+ *
+ * `accumulatedRewards` is dense from the stake's first epoch onward but resets
+ * to '0' at full-unstake epochs (see rewards-calculator.ts), so we look up the
+ * value at the largest recorded epoch that is still `< startEpoch` rather than
+ * assuming `startEpoch - 1` exists. Returns 0n when the stake only starts in or
+ * after the window (nothing to ignore).
+ */
+function getAccumulatedBefore(
+    accumulatedRewards: Record<number, string>,
+    startEpoch: number,
+): bigint {
+    let bestEpoch = -Infinity;
+    for (const epochStr of Object.keys(accumulatedRewards)) {
+        const epoch = Number(epochStr);
+        if (epoch < startEpoch && epoch > bestEpoch) bestEpoch = epoch;
+    }
+    if (bestEpoch === -Infinity) return 0n;
+    return safeBigInt(accumulatedRewards[bestEpoch]);
+}
+
+/**
+ * Re-baseline stake objects so that only rewards accrued from `startEpoch`
+ * onward are reflected — used by the "Ignore previous rewards" option when a
+ * narrower time frame than "All time" is selected.
+ *
+ * For each stake object we compute its pre-window earnings `B` (accumulated
+ * rewards just before `startEpoch`) and:
+ *   - zero out per-epoch and accumulated rewards before the window,
+ *   - subtract `B` from accumulated rewards within the window (clamped ≥ 0),
+ *   - subtract `B` from the realized rewards of unstake actions within the
+ *     window, distributing it across the object's window unstakes in epoch
+ *     order so multiple (partial) unstakes never over-subtract.
+ *
+ * Principal and exchange-rate maps are left untouched (principal is not a
+ * reward, so "Total Staked" stays correct). The returned `previousRewardsRemoved`
+ * is the sum of every object's `B` — the total previous reward shown in the
+ * "ignored" notice.
+ *
+ * Known limitation: `preTransferRewards` is left unchanged; a stake transferred
+ * in before the window keeps its original pre-transfer adjustment.
+ */
+export function rebaselineStakeObjects(
+    stakeObjects: StakeObject[],
+    startEpoch: number,
+): { stakeObjects: StakeObject[]; previousRewardsRemoved: bigint } {
+    let previousRewardsRemoved = 0n;
+
+    const rebased = stakeObjects.map((obj) => {
+        const baseline = getAccumulatedBefore(obj.accumulatedRewards, startEpoch);
+        previousRewardsRemoved += baseline;
+
+        const rewardsByEpoch: Record<number, string> = {};
+        for (const [epochStr, value] of Object.entries(obj.rewardsByEpoch)) {
+            rewardsByEpoch[Number(epochStr)] = Number(epochStr) < startEpoch ? '0' : value;
+        }
+
+        const accumulatedRewards: Record<number, string> = {};
+        for (const [epochStr, value] of Object.entries(obj.accumulatedRewards)) {
+            const epoch = Number(epochStr);
+            if (epoch < startEpoch) {
+                accumulatedRewards[epoch] = '0';
+            } else {
+                const rebasedValue = safeBigInt(value) - baseline;
+                accumulatedRewards[epoch] = (rebasedValue > 0n ? rebasedValue : 0n).toString();
+            }
+        }
+
+        let actionByEpoch = obj.actionByEpoch;
+        if (actionByEpoch && baseline > 0n) {
+            const next: Record<number, ActionDetails[]> = {};
+            // Absorb the pre-window baseline across this object's window unstakes
+            // in epoch order, capped at each action's realized rewards.
+            let remaining = baseline;
+            const orderedEpochs = Object.keys(actionByEpoch)
+                .map(Number)
+                .sort((a, b) => a - b);
+            for (const epoch of orderedEpochs) {
+                next[epoch] = actionByEpoch[epoch].map((action) => {
+                    if (
+                        epoch >= startEpoch &&
+                        remaining > 0n &&
+                        (action.action === 'Unstaked' || action.action === 'Partial Unstake') &&
+                        action.totalRewards
+                    ) {
+                        const original = safeBigInt(action.totalRewards);
+                        const subtract = original < remaining ? original : remaining;
+                        remaining -= subtract;
+                        return { ...action, totalRewards: (original - subtract).toString() };
+                    }
+                    return action;
+                });
+            }
+            actionByEpoch = next;
+        }
+
+        return {
+            ...obj,
+            rewardsByEpoch,
+            accumulatedRewards,
+            ...(actionByEpoch ? { actionByEpoch } : {}),
+        };
+    });
+
+    return { stakeObjects: rebased, previousRewardsRemoved };
+}
+
 /**
  * Get the first principal amount for a stake object.
  */

--- a/src/lib/pages/staking-rewards/types.ts
+++ b/src/lib/pages/staking-rewards/types.ts
@@ -117,6 +117,12 @@ export type ExportOptions = {
     wrapStakeObjects?: boolean;
     /** Same idea as `wrapStakeObjects`, but for validator columns. */
     wrapValidators?: boolean;
+    /**
+     * When the "Ignore previous rewards" option is active, a human-readable
+     * notice (e.g. "Previous rewards ignored: 31 IOTA — accrued before epoch
+     * 154") emitted at the top of the export so the figures are unambiguous.
+     */
+    previousRewardsNotice?: string;
 };
 
 /**

--- a/src/lib/pages/txs/fetchTransactions.ts
+++ b/src/lib/pages/txs/fetchTransactions.ts
@@ -238,7 +238,7 @@ export async function fetchTransactionsForAddress(
     address: string,
     options: FetchTransactionsOptions,
 ): Promise<{ txs: TransactionNode[]; nextCursor: string | null; hasMore: boolean }> {
-    const filterParts = [`signAddress: $address`];
+    const filterParts = [`sentAddress: $address`];
 
     if (options.afterCheckpoint && options.afterCheckpoint.trim()) {
         filterParts.push(`afterCheckpoint: ${parseInt(options.afterCheckpoint)}`);


### PR DESCRIPTION
## Summary

Adds the **"Ignore previous rewards"** option to the Staking Rewards page and fixes several fetch/correctness issues surfaced while building and testing it.

### Features
- **Ignore previous rewards toggle** — shown only when a time frame narrower than *All time* is selected, **off by default**. When on, rewards accrued before the window start are removed: `Accumulated`/`Available` re-base to the window, and each unstake is reduced by that stake's pre-window earnings (distributed across multiple unstakes so it never over-subtracts). The removed total is shown as a notice in the table and in **CSV/PDF exports**. When off, output is byte-for-byte unchanged.

### Fixes
- **`signAddress` → `sentAddress`** — the GraphQL server removed `signAddress` from `TransactionBlockFilter`; queries now use `sentAddress` (staking-rewards + txs pages).
- **Recover pruned input state** — a StakedIota created long ago and never modified has its historical version pruned from GraphQL, so the unstake's `inputState` is `null` and the unstake was silently dropped (only the re-stake showed). We now backfill it from the full node via `iota_tryGetPastObject` (bounded to `request_withdraw_stake*` txs), shaped to look like a normal `inputState` so the processor is unchanged.
- **Reconstruct pre-history in all-time mode** — `extendFirstEpochToActivation` now runs for *all-time* fetches too, not just time-frame fetches. Without this, a recovered unstake's accrued rewards were missing from `Accumulated`, undercounting `Available Rewards` and clamping it to zero where unstakes exceeded the incomplete accumulated. Only affects objects whose creation was never captured (`stakeActivationEpoch < firstEpoch`); normal objects are untouched.
- **Rate-limit resilience** — GraphQL queries retry on 429/transient network errors with exponential backoff + jitter, and per-address fetches are capped with a concurrency limit so large multi-address fetches don't trip the public endpoint.

## Verification
- `pnpm test` (222 tests), `pnpm check`, `pnpm lint` all pass.
- New unit tests: re-baseline math (incl. the worked example: 40 → 9 IOTA), multi-unstake non-over-subtraction, CSV notice presence/absence.
- Live-validated against mainnet: the previously-missing unstake (`35Z2…`) now appears with `totalRewards = 4,849,047,382,013` — exactly matching the on-chain `UnstakingRequestEvent`, yet computed independently via exchange rates. After the all-time fix, `available[239]` and the ignored-rewards total reconcile (both ~6,227 IOTA for the reported portfolio) and the clamped-to-zero `available` is gone.

## Note
This raises reported available-rewards numbers for portfolios that held old, since-unstaked stakes — those rewards were previously being dropped. It's a correctness improvement, but totals will differ from what the tool showed before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)