### PR TITLE
fix(build): make explorer build resilient when @iota/sdk-wasm is absent

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "test": "vitest --run",
         "test:ui": "vitest --ui",
         "dev:explorer": "pnpm --filter iota-explorer run dev",
-        "build:explorer": "pnpm --filter iota-explorer run build:integrated && rm -rf public/explorer && cp -R apps/explorer/dist public/explorer"
+        "build:explorer": "node scripts/build-explorer.js"
     },
     "license": "Apache-2.0",
     "devDependencies": {

--- a/scripts/build-explorer.js
+++ b/scripts/build-explorer.js
@@ -1,0 +1,56 @@
+import { execSync } from 'child_process';
+import { cpSync, existsSync, rmSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const explorerDir = join(root, 'apps/explorer');
+const explorerDist = join(explorerDir, 'dist');
+
+// Vite copies everything under `public/` into the build output, so staging the
+// explorer here is what lands it under `docs/explorer/` after `pnpm build`.
+const stagedDir = join(root, 'public/explorer');
+
+// The last built explorer output, committed to the repo and deployed as-is.
+const committedDir = join(root, 'docs/explorer');
+
+// The explorer is built on the `@iota/sdk-wasm` bindings, produced by compiling
+// the sibling `iota-rust-sdk` checkout to wasm (`make wasm`). That toolchain is
+// only present in a full dev setup; the data-only "Update Staking Rewards
+// Caches" CI job checks out iotatools alone. Detect the built bindings via the
+// type declarations they emit — the `link:` dependency in
+// apps/explorer/package.json points here.
+const wasmTypes = join(
+    explorerDir,
+    '../../../iota-rust-sdk/bindings/wasm/dist/types/index.web.d.ts',
+);
+
+function stageFrom(sourceDir) {
+    rmSync(stagedDir, { recursive: true, force: true });
+    cpSync(sourceDir, stagedDir, { recursive: true });
+}
+
+if (existsSync(wasmTypes)) {
+    // Bindings are available: rebuild from source. Let build failures surface
+    // as hard errors so real regressions in the explorer aren't masked.
+    execSync('pnpm --filter iota-explorer run build:integrated', {
+        stdio: 'inherit',
+        cwd: root,
+    });
+    stageFrom(explorerDist);
+    console.log('Explorer built from source and staged into public/explorer.');
+} else if (existsSync(committedDir)) {
+    // Bindings unavailable (e.g. the cache-update CI job): reuse the committed
+    // output so `pnpm build` still produces a complete docs/ that includes the
+    // explorer instead of dropping it.
+    console.warn(
+        '@iota/sdk-wasm bindings not built; reusing committed docs/explorer.\n' +
+            'To rebuild the explorer, run `make wasm` in the sibling iota-rust-sdk checkout.',
+    );
+    stageFrom(committedDir);
+} else {
+    console.warn(
+        '@iota/sdk-wasm bindings not built and no committed docs/explorer to reuse; ' +
+            'skipping explorer. The resulting build will not include /explorer.',
+    );
+}


### PR DESCRIPTION
## Why

The daily **Update Staking Rewards Caches** workflow ([failed run](https://github.com/Thoralf-M/iotatools/actions/runs/28790453857/job/85372153545)) runs `pnpm build`, which since #302 also builds the `apps/explorer` sub-app. The explorer depends on `@iota/sdk-wasm` via `link:../../../iota-rust-sdk/bindings/wasm` — a sibling repo that must be compiled to WASM (`make wasm`, needs the Rust toolchain). That cache-update job checks out `iotatools` alone, so the link dangles and `tsc -b` fails with `TS2307: Cannot find module '@iota/sdk-wasm'`.

Skipping the explorer naively isn't safe: `postbuild.js` does `rm -rf docs && mv dist docs`, and the deployed `docs/explorer` is only repopulated because `build:explorer` stages it into `public/explorer`. Skipping would delete the deployed explorer.

## What

Replace the inline `build:explorer` command with `scripts/build-explorer.js`:

- **WASM bindings present** (full dev setup) → rebuild from source, surfacing real build errors.
- **Bindings absent** (cache-update CI) → stage the already-committed `docs/explorer` so `pnpm build` still emits a complete `docs/` including `/explorer`.

## Test plan

Verified in a checkout that mirrors the CI job (no built WASM dist, `docs/explorer` committed):

- `pnpm build` exits 0
- rebuilt `docs/explorer` keeps all 45 files
- `docs/` round-trips with no diff (no spurious churn committed by the workflow)
- `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARjpx5XegHjFrHQAJbsWPV

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARjpx5XegHjFrHQAJbsWPV)_